### PR TITLE
run: should not chdir to script dir

### DIFF
--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -90,9 +90,7 @@ func IsDir(target string) (bool, error) {
 }
 
 func runFile(ctx *igop.Context, target string, args []string) {
-	dir, file := filepath.Split(target)
-	os.Chdir(dir)
-	exitCode, err := ctx.RunFile(file, nil, args)
+	exitCode, err := ctx.RunFile(target, nil, args)
 	if err != nil {
 		log.Println(err)
 	}
@@ -100,7 +98,6 @@ func runFile(ctx *igop.Context, target string, args []string) {
 }
 
 func runDir(ctx *igop.Context, dir string, args []string) {
-	os.Chdir(dir)
 	exitCode, err := ctx.Run(dir, args)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
目前的实现会先chdir到脚本所在目录，会导致在脚本里面获取到的当前目录是错误的。

```bash
$ cd /tmp
$ cat a/b/c/a.go
package main

import (
	"fmt"
	"os"
)

func main() {
	fmt.Println(os.Getwd())
}
$ go run ./a/b/c/a.go
/tmp <nil>
$ igop run ./a/b/c/a.go
/tmp/a/b/c <nil>
```