### PR TITLE
Update  igop install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ support ABI0 and ABIInternal
 - Go1.18 fuzzing
 
 ### igop command line
+
+Go version < 1.17:
 ```
 go get -u github.com/goplus/igop/cmd/igop
+```
+
+Go version >= 1.17:
+```
+go install github.com/goplus/igop/cmd/igop@latest
 ```
 
 Commands


### PR DESCRIPTION
https://go.dev/doc/go-get-install-deprecation
- Starting in Go 1.17, installing executables with go get is deprecated. 
- In Go 1.18, go get will no longer build packages.