### PR TITLE
LoadDir: support //go:embed

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -60,7 +60,7 @@ func buildCmd(cmd *base.Command, args []string) {
 		mode |= igop.EnableDumpInstr
 	}
 	if base.BuildX {
-		mode |= igop.EnableDumpImports
+		mode |= igop.EnableDumpImports | igop.EnableDumpEmbed
 	}
 	ctx := igop.NewContext(mode)
 	ctx.BuildContext = base.BuildContext

--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -69,7 +69,7 @@ func runCmd(cmd *base.Command, args []string) {
 		mode |= igop.EnableTracing
 	}
 	if base.BuildX {
-		mode |= igop.EnableDumpImports
+		mode |= igop.EnableDumpImports | igop.EnableDumpEmbed
 	}
 	ctx := igop.NewContext(mode)
 	ctx.BuildContext = base.BuildContext

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -97,7 +97,7 @@ func runCmd(cmd *base.Command, args []string) {
 		mode |= igop.EnableTracing
 	}
 	if base.BuildX {
-		mode |= igop.EnableDumpImports
+		mode |= igop.EnableDumpImports | igop.EnableDumpEmbed
 	}
 	ctx := igop.NewContext(mode)
 	ctx.BuildContext = base.BuildContext

--- a/context.go
+++ b/context.go
@@ -274,6 +274,13 @@ func (ctx *Context) loadPackage(bp *build.Package, path string, dir string) (*so
 	if err != nil {
 		return nil, err
 	}
+	if data, found := load.Embed(bp, ctx.FileSet, files, false, false); found {
+		f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data.go", data, 0)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, f)
+	}
 	tp := &sourcePackage{
 		Package: types.NewPackage(path, bp.Name),
 		Files:   files,
@@ -292,6 +299,13 @@ func (ctx *Context) loadTestPackage(bp *build.Package, path string, dir string) 
 	if err != nil {
 		return nil, err
 	}
+	if data, found := load.Embed(bp, ctx.FileSet, files, true, false); found {
+		f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data.go", data, 0)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, f)
+	}
 	tp := &sourcePackage{
 		Package: types.NewPackage(path, bp.Name),
 		Files:   files,
@@ -303,6 +317,13 @@ func (ctx *Context) loadTestPackage(bp *build.Package, path string, dir string) 
 		files, err := ctx.parseGoFiles(dir, bp.XTestGoFiles)
 		if err != nil {
 			return nil, err
+		}
+		if data, found := load.Embed(bp, ctx.FileSet, files, false, true); found {
+			f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data_test.go", data, 0)
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, f)
 		}
 		tp := &sourcePackage{
 			Package: types.NewPackage(path+"_test", bp.Name+"_test"),

--- a/context.go
+++ b/context.go
@@ -29,7 +29,8 @@ type Mode uint
 const (
 	DisableRecover       Mode = 1 << iota // Disable recover() in target programs; show interpreter crash instead.
 	DisableCustomBuiltin                  // Disable load custom builtin func
-	EnableDumpImports                     // print typesimports
+	EnableDumpImports                     // print import packages
+	EnableDumpEmbed                       // print embed files
 	EnableDumpInstr                       // Print packages & SSA instruction code
 	EnableTracing                         // Print a trace of all instructions as they are interpreted.
 	EnablePrintAny                        // Enable builtin print for any type ( struct/array )
@@ -275,6 +276,10 @@ func (ctx *Context) loadPackage(bp *build.Package, path string, dir string) (*so
 		return nil, err
 	}
 	if data, found := load.Embed(bp, ctx.FileSet, files, false, false); found {
+		if ctx.Mode&EnableDumpEmbed != 0 {
+			fmt.Println("# embed", bp.Dir)
+			fmt.Println(string(data))
+		}
 		f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data.go", data, 0)
 		if err != nil {
 			return nil, err
@@ -300,6 +305,10 @@ func (ctx *Context) loadTestPackage(bp *build.Package, path string, dir string) 
 		return nil, err
 	}
 	if data, found := load.Embed(bp, ctx.FileSet, files, true, false); found {
+		if ctx.Mode&EnableDumpEmbed != 0 {
+			fmt.Println("# embed", bp.Dir)
+			fmt.Println(string(data))
+		}
 		f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data.go", data, 0)
 		if err != nil {
 			return nil, err
@@ -319,6 +328,10 @@ func (ctx *Context) loadTestPackage(bp *build.Package, path string, dir string) 
 			return nil, err
 		}
 		if data, found := load.Embed(bp, ctx.FileSet, files, false, true); found {
+			if ctx.Mode&EnableDumpEmbed != 0 {
+				fmt.Println("# embed xtest", bp.Dir)
+				fmt.Println(string(data))
+			}
 			f, err := parser.ParseFile(ctx.FileSet, "_igop_embed_data_test.go", data, 0)
 			if err != nil {
 				return nil, err

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/peterh/liner v1.2.2
 	github.com/petermattis/goid v0.0.0-20220331194723-8ee3e6ded87a
 	github.com/visualfc/funcval v0.1.3
+	github.com/visualfc/goembed v0.2.2
 	github.com/visualfc/xtype v0.1.0
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/visualfc/funcval v0.1.3 h1:hvqP5bkW2jeA4cf7QNM8bz+duJECFzQmSBmMJkkIt3A=
 github.com/visualfc/funcval v0.1.3/go.mod h1:3Izv+irhArmrTvy+lmL6pIq16gSOzx73CIka51J9eR0=
+github.com/visualfc/goembed v0.2.2 h1:zmhrsIamFwtPHeVtD+ZJyfuKa3DRtjphI+160kGEnfQ=
+github.com/visualfc/goembed v0.2.2/go.mod h1:jCVCz/yTJGyslo6Hta+pYxWWBuq9ADCcIVZBTQ0/iVI=
 github.com/visualfc/xtype v0.1.0 h1:1seX3iD9v2YDORZa8Fas7CH280Fv3wulDOp2U+uPUF0=
 github.com/visualfc/xtype v0.1.0/go.mod h1:VYIH9S2bmdWKlBb7c725ES6yKF9+pyHBU2SFNqGVMGM=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/interp_go116_test.go
+++ b/interp_go116_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmbed(t *testing.T) {
-	_, err := igop.Run("./testdata/embed", nil, 0)
+	_, err := igop.Run("./testdata/embed", nil, igop.EnableDumpEmbed)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/interp_go116_test.go
+++ b/interp_go116_test.go
@@ -1,0 +1,18 @@
+//go:build go1.16
+// +build go1.16
+
+package igop_test
+
+import (
+	"testing"
+
+	"github.com/goplus/igop"
+	_ "github.com/goplus/igop/pkg/embed"
+)
+
+func TestEmbed(t *testing.T) {
+	_, err := igop.Run("./testdata/embed", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/interp_test.go
+++ b/interp_test.go
@@ -2318,7 +2318,7 @@ func main() {
 	}
 }
 
-func TestEmbed(t *testing.T) {
+func TestStructEmbed(t *testing.T) {
 	p := &igop.Package{
 		Name: "info",
 		Path: "github.com/goplus/igop/testdata/info",

--- a/load/embed_go115.go
+++ b/load/embed_go115.go
@@ -1,0 +1,14 @@
+//go:build !go1.16
+// +build !go1.16
+
+package load
+
+import (
+	"go/ast"
+	"go/build"
+	"go/token"
+)
+
+func Embed(bp *build.Package, fset *token.FileSet, files []*ast.File, test bool, xtest bool) ([]byte, bool) {
+	return nil, false
+}

--- a/load/embed_go116.go
+++ b/load/embed_go116.go
@@ -1,0 +1,110 @@
+//go:build go1.16
+// +build go1.16
+
+package load
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/token"
+	"strings"
+
+	"github.com/visualfc/goembed"
+)
+
+func buildIdent(name string) string {
+	return fmt.Sprintf("__igop_embed_%x__", name)
+}
+
+var embed_head = `package $pkg
+
+import (
+	"embed"
+	"unsafe"
+)
+
+func __igop_embed_buildFS__(list []struct {
+	name string
+	data string
+	hash [16]byte
+}) (f embed.FS) {
+	fs := struct {
+		files *[]struct {
+			name string
+			data string
+			hash [16]byte
+		}
+	}{&list}
+	return *(*embed.FS)(unsafe.Pointer(&fs))
+}
+`
+
+// Embed check package embed data
+func Embed(bp *build.Package, fset *token.FileSet, files []*ast.File, test bool, xtest bool) ([]byte, bool) {
+	var pkgName string
+	var ems []*goembed.Embed
+	if xtest {
+		pkgName = bp.Name + "_test"
+		ems = goembed.CheckEmbed(bp.XTestEmbedPatternPos, fset, files)
+	} else {
+		pkgName = bp.Name
+		ems = goembed.CheckEmbed(bp.EmbedPatternPos, fset, files)
+		if test {
+			if tems := goembed.CheckEmbed(bp.TestEmbedPatternPos, fset, files); len(tems) > 0 {
+				ems = append(ems, tems...)
+			}
+		}
+	}
+	if len(ems) == 0 {
+		return nil, false
+	}
+	r := goembed.NewResolve()
+	var buf bytes.Buffer
+	buf.WriteString(strings.Replace(embed_head, "$pkg", pkgName, 1))
+	buf.WriteString("\nvar (\n")
+	for _, v := range ems {
+		v.Spec.Names[0].Name = "_"
+		fs, _ := r.Load(bp.Dir, v)
+		switch v.Kind {
+		case goembed.EmbedBytes:
+			buf.WriteString(fmt.Sprintf("\t%v = []byte(%v)\n", v.Name, buildIdent(fs[0].Name)))
+		case goembed.EmbedString:
+			buf.WriteString(fmt.Sprintf("\t%v = %v\n", v.Name, buildIdent(fs[0].Name)))
+		case goembed.EmbedFiles:
+			fs = goembed.BuildFS(fs)
+			buf.WriteString(fmt.Sprintf("\t%v=", v.Name))
+			buf.WriteString(`__igop_embed_buildFS__(
+[]struct {
+	name string
+	data string
+	hash [16]byte
+}{
+`)
+			for _, f := range fs {
+				if len(f.Data) == 0 {
+					buf.WriteString(fmt.Sprintf("\t{\"%v\",\"\",[16]byte{}},\n",
+						f.Name))
+				} else {
+					buf.WriteString(fmt.Sprintf("\t{\"%v\",%v,[16]byte{%v}},\n",
+						f.Name, buildIdent(f.Name), goembed.BytesToList(f.Hash[:])))
+				}
+			}
+			buf.WriteString("})\n")
+		}
+	}
+	buf.WriteString("\n)\n")
+	buf.WriteString("\nvar (\n")
+	for _, f := range r.Files() {
+		if len(f.Data) == 0 {
+			buf.WriteString(fmt.Sprintf("\t%v string\n",
+				buildIdent(f.Name)))
+		} else {
+			buf.WriteString(fmt.Sprintf("\t%v = string(\"%v\")\n",
+				buildIdent(f.Name), goembed.BytesToHex(f.Data)))
+		}
+	}
+	buf.WriteString(")\n\n")
+	return buf.Bytes(), true
+}

--- a/load/embed_go116.go
+++ b/load/embed_go116.go
@@ -74,9 +74,8 @@ func Embed(bp *build.Package, fset *token.FileSet, files []*ast.File, test bool,
 			buf.WriteString(fmt.Sprintf("\t%v = %v\n", v.Name, buildIdent(fs[0].Name)))
 		case goembed.EmbedFiles:
 			fs = goembed.BuildFS(fs)
-			buf.WriteString(fmt.Sprintf("\t%v=", v.Name))
-			buf.WriteString(`__igop_embed_buildFS__(
-[]struct {
+			buf.WriteString(fmt.Sprintf("\t%v = ", v.Name))
+			buf.WriteString(`__igop_embed_buildFS__([]struct {
 	name string
 	data string
 	hash [16]byte

--- a/testdata/embed/embed.go
+++ b/testdata/embed/embed.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"embed"
+)
+
+//go:embed testdata/data1.txt
+var data1 string
+
+//go:embed testdata/data2.txt
+var data2 []byte
+
+//go:embed testdata/*
+var fs embed.FS
+
+func main() {
+	if data1 != "hello data1" {
+		panic(data1)
+	}
+	if string(data2) != "hello data2" {
+		panic(data2)
+	}
+	data, err := fs.ReadFile("testdata/sub/data2.txt")
+	if err != nil {
+		panic(err)
+	}
+	if string(data) != "sub data2" {
+		panic(data)
+	}
+}

--- a/testdata/embed/testdata/data1.txt
+++ b/testdata/embed/testdata/data1.txt
@@ -1,0 +1,1 @@
+hello data1

--- a/testdata/embed/testdata/data2.txt
+++ b/testdata/embed/testdata/data2.txt
@@ -1,0 +1,1 @@
+hello data2

--- a/testdata/embed/testdata/sub/data1.txt
+++ b/testdata/embed/testdata/sub/data1.txt
@@ -1,0 +1,1 @@
+sub data1

--- a/testdata/embed/testdata/sub/data2.txt
+++ b/testdata/embed/testdata/sub/data2.txt
@@ -1,0 +1,1 @@
+sub data2


### PR DESCRIPTION
fix https://github.com/goplus/igop/issues/151

source
```
package main

import (
	"embed"
)

//go:embed testdata/data1.txt
var data1 string

//go:embed testdata/data2.txt
var data2 []byte

//go:embed testdata/*
var fs embed.FS
```
generate embed data
```
# embed testdata/embed
package main

import (
	"embed"
	"unsafe"
)

func __igop_embed_buildFS__(list []struct {
	name string
	data string
	hash [16]byte
}) (f embed.FS) {
	fs := struct {
		files *[]struct {
			name string
			data string
			hash [16]byte
		}
	}{&list}
	return *(*embed.FS)(unsafe.Pointer(&fs))
}

var (
	data1 = __igop_embed_74657374646174612f64617461312e747874__
	data2 = []byte(__igop_embed_74657374646174612f64617461322e747874__)
	fs = __igop_embed_buildFS__([]struct {
	name string
	data string
	hash [16]byte
}{
	{"testdata/","",[16]byte{}},
	{"testdata/data1.txt",__igop_embed_74657374646174612f64617461312e747874__,[16]byte{107,20,187,116,251,123,58,207,47,22,220,232,140,252,110,34}},
	{"testdata/data2.txt",__igop_embed_74657374646174612f64617461322e747874__,[16]byte{118,204,101,190,98,212,195,245,179,90,84,12,174,225,240,49}},
	{"testdata/sub/","",[16]byte{}},
	{"testdata/sub/data1.txt",__igop_embed_74657374646174612f7375622f64617461312e747874__,[16]byte{21,21,211,92,135,76,57,70,81,175,220,119,195,209,124,129}},
	{"testdata/sub/data2.txt",__igop_embed_74657374646174612f7375622f64617461322e747874__,[16]byte{194,154,211,45,220,151,246,175,114,60,231,76,113,202,100,136}},
})

)

var (
	__igop_embed_74657374646174612f64617461312e747874__ = string("\x68\x65\x6c\x6c\x6f\x20\x64\x61\x74\x61\x31")
	__igop_embed_74657374646174612f64617461322e747874__ = string("\x68\x65\x6c\x6c\x6f\x20\x64\x61\x74\x61\x32")
	__igop_embed_74657374646174612f7375622f64617461312e747874__ = string("\x73\x75\x62\x20\x64\x61\x74\x61\x31")
	__igop_embed_74657374646174612f7375622f64617461322e747874__ = string("\x73\x75\x62\x20\x64\x61\x74\x61\x32")
)

```