### PR TITLE
check unsafe.Slice len out of range

### DIFF
--- a/cmd/igoptest/main.go
+++ b/cmd/igoptest/main.go
@@ -61,10 +61,6 @@ func init() {
 
 	ver := runtime.Version()[:6]
 	switch ver {
-	case "go1.18", "go1.19":
-		gorootTestSkips["unsafebuiltins.go"] = "TODO"
-	}
-	switch ver {
 	case "go1.17", "go1.18", "go1.19":
 		gorootTestSkips["fixedbugs/issue45045.go"] = "runtime.SetFinalizer"
 		gorootTestSkips["fixedbugs/issue46725.go"] = "runtime.SetFinalizer"


### PR DESCRIPTION
fix https://github.com/goplus/igop/issues/178

runtime.unsafeslice
```
func unsafeslice(et *_type, ptr unsafe.Pointer, len int) {
	if len < 0 {
		panicunsafeslicelen()
	}

	mem, overflow := math.MulUintptr(et.size, uintptr(len))
	if overflow || mem > -uintptr(ptr) {
		if ptr == nil {
			panic(errorString("unsafe.Slice: ptr is nil and len is not zero"))
		}
		panicunsafeslicelen()
	}
}
```