### PR TITLE
no strict mode

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -582,7 +582,7 @@ func builtinOffsetof(pfn *function, pc int) (int64, error) {
 		return -1, plainError("unsafe.Offsetof not found FieldAddr instr")
 	}
 	instr := instrs[len(sel.Index())-1]
-	return selOffsetof(pfn.Interp.ctx.conf.Sizes, instr.X.Type().Underlying().(*types.Pointer).Elem().Underlying().(*types.Struct), sel.Index(), selx.Sel.Name)
+	return selOffsetof(pfn.Interp.ctx.sizes, instr.X.Type().Underlying().(*types.Pointer).Elem().Underlying().(*types.Struct), sel.Index(), selx.Sel.Name)
 }
 
 func foundFieldAddr(pfn *function, pc int) (instrs []*ssa.FieldAddr, found bool) {

--- a/context.go
+++ b/context.go
@@ -101,14 +101,16 @@ func (sp *sourcePackage) Load() (err error) {
 			Sizes:    sp.Context.sizes,
 			Importer: NewImporter(sp.Context),
 		}
-		if sp.Context.evalMode || sp.Context.Mode&EnableNoStrict != 0 {
+		if sp.Context.evalMode {
 			conf.DisableUnusedImportCheck = true
 		}
 		if sp.Context.Mode&EnableNoStrict != 0 {
 			conf.Error = func(e error) {
-				if te, ok := e.(types.Error); ok && strings.HasSuffix(te.Msg, errDeclNotUsed) {
-					println(fmt.Sprintf("igop warning: %v", e))
-					return
+				if te, ok := e.(types.Error); ok {
+					if strings.HasSuffix(te.Msg, errDeclaredNotUsed) || strings.HasSuffix(te.Msg, errImportedNotUsed) {
+						println(fmt.Sprintf("igop warning: %v", e))
+						return
+					}
 				}
 				if err == nil {
 					err = e

--- a/context.go
+++ b/context.go
@@ -34,6 +34,7 @@ const (
 	EnableDumpInstr                       // Print packages & SSA instruction code
 	EnableTracing                         // Print a trace of all instructions as they are interpreted.
 	EnablePrintAny                        // Enable builtin print for any type ( struct/array )
+	EnableNoStrict                        // Enable no strict mode
 )
 
 // Loader types loader interface

--- a/context.go
+++ b/context.go
@@ -94,6 +94,38 @@ type sourcePackage struct {
 	Files   []*ast.File
 }
 
+func (sp *sourcePackage) Load() (err error) {
+	if sp.Info == nil {
+		sp.Info = newTypesInfo()
+		conf := &types.Config{
+			Sizes:    sp.Context.sizes,
+			Importer: NewImporter(sp.Context),
+		}
+		if sp.Context.evalMode || sp.Context.Mode&EnableNoStrict != 0 {
+			conf.DisableUnusedImportCheck = true
+		}
+		if sp.Context.Mode&EnableNoStrict != 0 {
+			conf.Error = func(e error) {
+				if te, ok := e.(types.Error); ok && strings.HasSuffix(te.Msg, errDeclNotUsed) {
+					println(fmt.Sprintf("igop warning: %v", e))
+					return
+				}
+				if err == nil {
+					err = e
+				}
+			}
+		} else {
+			conf.Error = func(e error) {
+				if err == nil {
+					err = e
+				}
+			}
+		}
+		types.NewChecker(conf, sp.Context.FileSet, sp.Package, sp.Info).Files(sp.Files)
+	}
+	return
+}
+
 // NewContext create a new Context
 func NewContext(mode Mode) *Context {
 	ctx := &Context{

--- a/context.go
+++ b/context.go
@@ -53,7 +53,7 @@ type Context struct {
 	BuildContext build.Context                                    // build context
 	output       io.Writer                                        // capture print/println output
 	FileSet      *token.FileSet                                   // file set
-	conf         *types.Config                                    // types check config
+	sizes        types.Sizes                                      // types unsafe sizes
 	Lookup       func(root, path string) (dir string, found bool) // lookup external import
 	evalCallFn   func(interp *Interp, call *ssa.Call, res ...interface{})
 	debugFunc    func(*DebugInfo)          // debug func
@@ -111,10 +111,7 @@ func NewContext(mode Mode) *Context {
 	if mode&EnableDumpInstr != 0 {
 		ctx.BuilderMode |= ssa.PrintFunctions
 	}
-	ctx.conf = &types.Config{
-		Sizes:    types.SizesFor("gc", runtime.GOARCH),
-		Importer: NewImporter(ctx),
-	}
+	ctx.sizes = types.SizesFor("gc", runtime.GOARCH)
 	ctx.Lookup = new(load.ListDriver).Lookup
 	return ctx
 }
@@ -125,12 +122,11 @@ func (ctx *Context) IsEvalMode() bool {
 
 func (ctx *Context) SetEvalMode(b bool) {
 	ctx.evalMode = b
-	ctx.conf.DisableUnusedImportCheck = b
 }
 
 // SetUnsafeSizes set the sizing functions for package unsafe.
 func (ctx *Context) SetUnsafeSizes(sizes types.Sizes) {
-	ctx.conf.Sizes = sizes
+	ctx.sizes = sizes
 }
 
 // SetLeastCallForEnablePool set least call count for enable function pool, default 64

--- a/errstring.go
+++ b/errstring.go
@@ -4,7 +4,8 @@
 package igop
 
 const (
-	errDeclNotUsed      = "declared but not used"
-	errAppendOutOfRange = "growslice: cap out of range"
-	errSliceToArrayPointer     = "cannot convert slice with length %v to pointer to array with length %v"
+	errDeclaredNotUsed     = "declared but not used"
+	errImportedNotUsed     = "imported but not used"
+	errAppendOutOfRange    = "growslice: cap out of range"
+	errSliceToArrayPointer = "cannot convert slice with length %v to pointer to array with length %v"
 )

--- a/errstring_go120.go
+++ b/errstring_go120.go
@@ -4,7 +4,8 @@
 package igop
 
 const (
-	errDeclNotUsed         = "declared and not used"
+	errDeclaredNotUsed     = "declared and not used"
+	errImportedNotUsed     = "imported and not used"
 	errAppendOutOfRange    = "len out of range"
 	errSliceToArrayPointer = "cannot convert slice with length %v to array or pointer to array with length %v"
 )

--- a/interp_test.go
+++ b/interp_test.go
@@ -3130,3 +3130,21 @@ func main() {
 		t.Fatal(err)
 	}
 }
+
+func TestNoStrictMode(t *testing.T) {
+	src := `package main
+import "fmt"
+
+func f() int
+
+func main() {
+	var a int
+	println(100)
+}
+`
+	ctx := igop.NewContext(igop.EnableNoStrict)
+	_, err := ctx.RunFile("main.go", src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/repl.go
+++ b/repl.go
@@ -185,8 +185,8 @@ func (r *Repl) eval(tok token.Token, expr string) (err error) {
 			if !ok {
 				return e
 			}
-			if strings.HasSuffix(e.Msg, errDeclNotUsed) {
-				v := e.Msg[0 : len(e.Msg)-len(errDeclNotUsed)-1]
+			if strings.HasSuffix(e.Msg, errDeclaredNotUsed) {
+				v := e.Msg[0 : len(e.Msg)-len(errDeclaredNotUsed)-1]
 				fixed = append(fixed, "__igop_repl_used__(&"+v+")")
 				// fixed = append(fixed, "__igop_repl_dump__("+v+")")
 			} else if strings.HasSuffix(e.Msg, errIsNotUsed) {

--- a/types_go117.go
+++ b/types_go117.go
@@ -50,19 +50,13 @@ func (r *TypesRecord) LookupReflect(typ types.Type) (rt reflect.Type, ok bool, n
 	return
 }
 
-func (sp *sourcePackage) Load() (err error) {
-	if sp.Info == nil {
-		sp.Info = &types.Info{
-			Types:      make(map[ast.Expr]types.TypeAndValue),
-			Defs:       make(map[*ast.Ident]types.Object),
-			Uses:       make(map[*ast.Ident]types.Object),
-			Implicits:  make(map[ast.Node]types.Object),
-			Scopes:     make(map[ast.Node]*types.Scope),
-			Selections: make(map[*ast.SelectorExpr]*types.Selection),
-		}
-		if err := types.NewChecker(sp.Context.conf, sp.Context.FileSet, sp.Package, sp.Info).Files(sp.Files); err != nil {
-			return err
-		}
+func newTypesInfo() *types.Info {
+	return &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
 	}
-	return
 }

--- a/types_go118.go
+++ b/types_go118.go
@@ -4,7 +4,6 @@
 package igop
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 	"reflect"
@@ -148,42 +147,14 @@ func (r *TypesRecord) LookupReflect(typ types.Type) (rt reflect.Type, ok bool, n
 	return
 }
 
-func (sp *sourcePackage) Load() (err error) {
-	if sp.Info == nil {
-		sp.Info = &types.Info{
-			Types:      make(map[ast.Expr]types.TypeAndValue),
-			Defs:       make(map[*ast.Ident]types.Object),
-			Uses:       make(map[*ast.Ident]types.Object),
-			Implicits:  make(map[ast.Node]types.Object),
-			Scopes:     make(map[ast.Node]*types.Scope),
-			Selections: make(map[*ast.SelectorExpr]*types.Selection),
-			Instances:  make(map[*ast.Ident]types.Instance),
-		}
-		conf := &types.Config{
-			Sizes:    sp.Context.sizes,
-			Importer: NewImporter(sp.Context),
-		}
-		if sp.Context.evalMode || sp.Context.Mode&EnableNoStrict != 0 {
-			conf.DisableUnusedImportCheck = true
-		}
-		if sp.Context.Mode&EnableNoStrict != 0 {
-			conf.Error = func(e error) {
-				if te, ok := e.(types.Error); ok && strings.HasSuffix(te.Msg, errDeclNotUsed) {
-					println(fmt.Sprintf("igop warning: %v", e))
-					return
-				}
-				if err == nil {
-					err = e
-				}
-			}
-		} else {
-			conf.Error = func(e error) {
-				if err == nil {
-					err = e
-				}
-			}
-		}
-		types.NewChecker(conf, sp.Context.FileSet, sp.Package, sp.Info).Files(sp.Files)
+func newTypesInfo() *types.Info {
+	return &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Instances:  make(map[*ast.Ident]types.Instance),
 	}
-	return
 }


### PR DESCRIPTION
```
package main

import (
    "github.com/goplus/igop"
    _ "github.com/goplus/igop/pkg/fmt"
)

src := `package main
import "fmt"

func f() int

func main() {
	var a int
	println(100)
}
`
func main() {
    ctx := igop.NewContext(igop.EnableNoStrict)
    _, err := ctx.RunFile("main.go", src, nil)
    if err != nil {
	    panic(err)
    }
}
```
output 
```
igop warning: main.go:7:6: a declared but not used
igop warning: main.go:2:8: "fmt" imported but not used
igop warning: main.go:4:6: main.f missing function body
100
```