### PR TITLE
support user func type convert

### DIFF
--- a/cmd/igop/gox_support.go
+++ b/cmd/igop/gox_support.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+package main
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	_ "unsafe"
+
+	"github.com/goplus/igop"
+)
+
+type operandMode byte
+type builtinId int
+
+type operand struct {
+	mode operandMode
+	expr ast.Expr
+	typ  types.Type
+	val  constant.Value
+	id   builtinId
+}
+
+type positioner interface {
+	Pos() token.Pos
+}
+
+//go:linkname checker_infer go/types.(*Checker).infer
+func checker_infer(check *types.Checker, posn positioner, tparams []*types.TypeParam, targs []types.Type, params *types.Tuple, args []*operand) (result []types.Type)
+
+func init() {
+	igop.RegisterExternal("github.com/goplus/gox.checker_infer", checker_infer)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/visualfc/funcval v0.1.3
 	github.com/visualfc/goembed v0.3.2
 	github.com/visualfc/goid v0.2.0
-	github.com/visualfc/xtype v0.1.2
+	github.com/visualfc/xtype v0.2.0
 	golang.org/x/mod v0.7.0
 	golang.org/x/tools v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/visualfc/goembed v0.3.2 h1:a9m6o9VTzNk3mEF98C8cHp8f8P8BblyjsjajXGfTp8
 github.com/visualfc/goembed v0.3.2/go.mod h1:jCVCz/yTJGyslo6Hta+pYxWWBuq9ADCcIVZBTQ0/iVI=
 github.com/visualfc/goid v0.2.0 h1:pI0+dZbw4lkBIez4rfnSuBuylMxfBEyrvLMozZ/MYhM=
 github.com/visualfc/goid v0.2.0/go.mod h1:FbMR/SOVBzAn7vM+tiZQ/++TmpeOKiLvfTa4uKD6bJE=
-github.com/visualfc/xtype v0.1.2 h1:ZIjycXC/lWZPQdYi0a4za93pucoxevRhkUHOTSUYKvE=
-github.com/visualfc/xtype v0.1.2/go.mod h1:183MDtzLqyDkCm5zCH42vJGq/aQE5W25k3Z6UOZxLF0=
+github.com/visualfc/xtype v0.2.0 h1:0ESNXyWHtK01kaOzOyqHsR1ZjEPdNu/IWPZkf0VOHl8=
+github.com/visualfc/xtype v0.2.0/go.mod h1:183MDtzLqyDkCm5zCH42vJGq/aQE5W25k3Z6UOZxLF0=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/opblock.go
+++ b/opblock.go
@@ -254,7 +254,8 @@ func findExternFunc(interp *Interp, fn *ssa.Function) (ext reflect.Value, ok boo
 	ext, ok = findUserFunc(interp, fnName)
 	if ok {
 		typ := interp.preToType(fn.Type())
-		if typ != ext.Type() {
+		ftyp := ext.Type()
+		if typ != ftyp && (typ.NumIn() == ftyp.NumIn() && typ.NumOut() == ftyp.NumOut()) {
 			ext = xtype.ConvertFunc(ext, xtype.TypeOfType(typ))
 		}
 		return

--- a/opblock.go
+++ b/opblock.go
@@ -249,13 +249,37 @@ func findUserFunc(interp *Interp, fnName string) (ext reflect.Value, ok bool) {
 	return
 }
 
+func checkFuncCompatible(t1, t2 reflect.Type) bool {
+	i1 := t1.NumIn()
+	i2 := t2.NumIn()
+	if i1 != i2 {
+		return false
+	}
+	o1 := t1.NumOut()
+	o2 := t2.NumOut()
+	if o1 != o2 {
+		return false
+	}
+	for i := 0; i < i1; i++ {
+		if t1.In(i).Size() != t2.In(i).Size() {
+			return false
+		}
+	}
+	for i := 0; i < o1; i++ {
+		if t1.Out(i).Size() != t2.Out(i).Size() {
+			return false
+		}
+	}
+	return true
+}
+
 func findExternFunc(interp *Interp, fn *ssa.Function) (ext reflect.Value, ok bool) {
 	fnName := fn.String()
 	ext, ok = findUserFunc(interp, fnName)
 	if ok {
 		typ := interp.preToType(fn.Type())
 		ftyp := ext.Type()
-		if typ != ftyp && (typ.NumIn() == ftyp.NumIn() && typ.NumOut() == ftyp.NumOut()) {
+		if typ != ftyp && checkFuncCompatible(typ, ftyp) {
 			ext = xtype.ConvertFunc(ext, xtype.TypeOfType(typ))
 		}
 		return


### PR DESCRIPTION
igop.RegisterExternal and (*Context).SetOverrideFunction enable compatible func

```
func TestUserFuncConvert(t *testing.T) {
	src := `package main

import "fmt"

type myint int
type point struct {
	x int
	y int
}

func mytest1(n myint, pt point) myint
func mytest2(n myint, pt *point) myint


func main() {
	n := mytest1(100, point{100,200})
	if n != 400 {
		panic(fmt.Errorf("error mytest1, must 400, have %v",n))
	}
	n = mytest2(100, &point{100,200})
	if n != 30000 {
		panic(fmt.Errorf("error mytest2, must 30000, have %v",n))
	}
}
`
	ctx := igop.NewContext(0)
	igop.RegisterExternal("main.mytest1", func(n int, pt struct {
		x int
		y int
	}) int {
		return n + pt.x + pt.y
	})
	ctx.SetOverrideFunction("main.mytest2", func(n int, pt *struct {
		x int
		y int
	}) int {
		return n * (pt.x + pt.y)
	})
	_, err := ctx.RunFile("main.go", src, nil)
	if err != nil {
		t.Fatal(err)
	}
}

```